### PR TITLE
add params to package and remove params from offer

### DIFF
--- a/src/offer.ts
+++ b/src/offer.ts
@@ -81,21 +81,3 @@ export const vendor_addons = "/vendor-addons/{vendor_id}";
 export const all_addons = "/api/offers/addons/all/{?limit,page}";
 
 export const wishlist = "/api/wishlist";
-
-/**
- * Move deprecated templates to the bottom
- * so we can remove them on a mayor release
- **/
-
-// Todo: Remove this on a mayor release
-export const public_bedbank_offer =
-  "/api/public-offers/bedbank/{id}" +
-  qargs(
-    "platform",
-    "region",
-    "brand",
-    "user_id",
-    "check_in",
-    "check_out",
-    "occupancy*"
-  );

--- a/src/offer.ts
+++ b/src/offer.ts
@@ -50,20 +50,11 @@ export const public_offer_packages =
 
 export const publicOfferPackages =
   "/api/v2/public-offers/{offerId}/packages" +
-  qargs("region", "brand", "offerType");
+  qargs("brand", "checkIn", "checkOut", "occupancy*", "offerType", "region");
 
 export const publicOffer =
   "/api/v2/public-offers/{id}" +
-  qargs(
-    "platform",
-    "region",
-    "brand",
-    "userId",
-    "checkIn",
-    "checkOut",
-    "occupancy*",
-    "offerType"
-  );
+  qargs("platform", "region", "brand", "userId", "offerType");
 
 export const vendor = "/api/vendor/{id}";
 export const vendor_offers = "/api/vendor-offers{?email}";
@@ -106,26 +97,5 @@ export const public_bedbank_offer =
     "user_id",
     "check_in",
     "check_out",
-    "occupancy*"
-  );
-
-// Todo: Remove this on a mayor release
-export const public_bedbank_offer_packages =
-  "/api/public-offers/bedbank/{offer_id}/packages" + qargs("region", "brand");
-
-// Todo: Remove this on a mayor release
-export const publicBedbankOfferPackages =
-  "/api/public-offers/bedbank/{offerId}/packages" + qargs("region", "brand");
-
-// Todo: Remove this on a mayor release
-export const publicBedbankOffer =
-  "/api/public-offers/bedbank/{id}" +
-  qargs(
-    "platform",
-    "region",
-    "brand",
-    "userId",
-    "checkIn",
-    "checkOut",
     "occupancy*"
   );


### PR DESCRIPTION
This PR has braking changes, going to release as a major update.

This PR removes the checking checkout and capacity fields from the bedbank offer and moves them to the package.
The offer route will only be used to load the initial offer.
The packages route will be used to load the room information after we have both check-in/checkout information and capacity.

