### PR TITLE
Autocompletion for templates and their parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 Published templates:
 
 ```js
-const templates = require('lib-uri-templates');
-const template = templates.get('properties');
+const uri = require('lib-uri-templates');
+const template = uri.templates.reservation.properties;
+// Or legacy API:
+// const template = uri.get('properties');
 
 template.rfc6570                              // '/api/properties{?id_salesforce_external,limit,page}'
 template.expand({id_salesforce_external: 1})  // '/api/properties?id_salesforce_external=1
@@ -15,8 +17,8 @@ template.expand({id_salesforce_external: 1})  // '/api/properties?id_salesforce_
 Development templates:
 
 ```js
-const templates = require('lib-uri-templates');
-const template = templates.mock('/api/properties{?id_salesforce_external,limit,page}')
+const uri = require('lib-uri-templates');
+const template = uri.mock('/api/properties{?id_salesforce_external,limit,page}')
 
 template.rfc6570                              // '/api/properties{?id_salesforce_external,limit,page}'
 template.expand({id_salesforce_external: 1})  // '/api/properties?id_salesforce_external=1

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "src"
   ],
   "dependencies": {
-    "url-template": "^2.0.8"
+    "url-template": "^2.0.8",
+    "uri-template-param-types": "^0.2.0"
   },
   "devDependencies": {
     "@types/assert": "^1.5.2",
@@ -37,6 +38,6 @@
     "mocha": "^8.1.3",
     "prettier": "^2.1.2",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.3"
+    "typescript": "^4.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-uri-templates",
-  "version": "1.5.7",
+  "version": "1.6.0",
   "description": "All our routes in a repo for profit",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,8 +1,5 @@
-import qargs from "./qargs";
+export const users = "/api/users/{user_id}{?brand}";
 
-export const users = "/api/users/{user_id}" + qargs("brand");
+export const user_memberships = "/api/users/{user_id}/memberships{?brand}";
 
-export const user_memberships =
-  "/api/users/{user_id}/memberships" + qargs("brand");
-
-export const current_user = "/api/users/current" + qargs("brand");
+export const current_user = "/api/users/current{?brand}";

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -1,36 +1,5 @@
-import qargs from "./qargs";
-
 export const calendar_months =
-  "/api/calendar/months" +
-  qargs(
-    "offer_id",
-    "package_id",
-    "origin",
-    "region",
-    "number_of_adults",
-    "number_of_children",
-    "number_of_infants",
-    "number_of_packages",
-    "provider*",
-    "min_date",
-    "match_surcharge",
-    "timezone_offset"
-  );
+  "/api/calendar/months{?offer_id,package_id,origin,region,number_of_adults,number_of_children,number_of_infants,number_of_packages,provider*,min_date,match_surcharge,timezone_offset}";
 
 export const calendar_days =
-  "/api/calendar/days" +
-  qargs(
-    "offer_id",
-    "package_id",
-    "origin",
-    "region",
-    "number_of_nights",
-    "number_of_adults",
-    "number_of_children",
-    "number_of_infants",
-    "number_of_packages",
-    "provider*",
-    "min_date",
-    "match_surcharge",
-    "timezone_offset"
-  );
+  "/api/calendar/days{?offer_id,package_id,origin,region,number_of_nights,number_of_adults,number_of_children,number_of_infants,number_of_packages,provider*,min_date,match_surcharge,timezone_offset}";

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,11 +1,9 @@
-import qargs from "./qargs";
-
 export const giftcard_terms_and_conditions =
   "/legal/giftcard-terms-and-conditions";
 export const how_we_calculate_percentage_off =
   "/legal/how-we-calculate-percentage-off";
 export const legal = "/legal";
-export const regions = "/regions" + qargs("brand", "no_detect");
+export const regions = "/regions{?brand,no_detect}";
 
 export const about_us = "/info/about-us";
 export const info = "/info";

--- a/src/flight.ts
+++ b/src/flight.ts
@@ -1,22 +1,8 @@
-import qargs from "./qargs";
-
 export const flight_single_cheapest =
-  "/api/flights/single-cheapest-search" +
-  qargs(
-    "start_date",
-    "end_date",
-    "origin",
-    "destination",
-    "currency",
-    "number_of_adults",
-    "number_of_nights",
-    "brand",
-    "provider*",
-    "region"
-  );
+  "/api/flights/single-cheapest-search{?start_date,end_date,origin,destination,currency,number_of_adults,number_of_nights,brand,provider*,region}";
 
 export const flight_fare_rules =
   "/api/flights/fare-rules{?journey_id,provider,carrier,booking_class,fare_rule_type}";
 
 export const flight_airports =
-  "/api/flights/airports" + qargs("brand", "region", "latitude", "longitude");
+  "/api/flights/airports{?brand,region,latitude,longitude}";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import urlTemplate from "url-template";
+import { URIParams } from "uri-template-param-types";
 
 import * as order from "./order";
 import * as reservation from "./reservation";
@@ -12,11 +13,11 @@ import * as content from "./content";
 import * as payment from "./payment";
 import * as voucher from "./voucher";
 
-type ExpandFunc = (query?: object) => string; // eslint-disable-line
+type ExpandFunc<Def extends string> = (query?: URIParams<Def>) => string;
 
 interface Template<Def extends string = string> {
   readonly rfc6570: Def;
-  readonly expand: ExpandFunc;
+  readonly expand: ExpandFunc<Def>;
 }
 
 interface ListItem {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,8 @@ import * as voucher from "./voucher";
 
 type ExpandFunc = (query?: object) => string; // eslint-disable-line
 
-interface Template {
-  readonly rfc6570: string;
+interface Template<Def extends string = string> {
+  readonly rfc6570: Def;
   readonly expand: ExpandFunc;
 }
 
@@ -47,7 +47,7 @@ const definitions: Definitions = {
   ...voucher,
 };
 
-function build(rfc6570: string): Template {
+function build<Def extends string = string>(rfc6570: Def): Template<Def> {
   const builder = urlTemplate.parse(rfc6570);
   return {
     expand: (query): string => builder.expand(query),
@@ -60,7 +60,7 @@ export function get(name: string): Template {
   return build(rfc6570);
 }
 
-export function mock(rfc6570: string): Template {
+export function mock<Def extends string>(rfc6570: Def): Template<Def> {
   return build(rfc6570);
 }
 
@@ -76,14 +76,14 @@ export function list(): ListItems {
 
 function buildAll<Defs extends Definitions>(
   definitions: Defs
-): { [name in keyof Defs]: Template } {
+): { [name in keyof Defs]: Template<Defs[name]> } {
   const templates = Object.keys(definitions).reduce<{
     [key: string]: Template;
   }>((templates, name) => {
     templates[name] = build(definitions[name]);
     return templates;
   }, {});
-  return templates as { [name in keyof Defs]: Template };
+  return templates as { [name in keyof Defs]: Template<Defs[name]> };
 }
 
 export const templates = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,3 +73,30 @@ export function list(): ListItems {
     return acc;
   }, {});
 }
+
+function buildAll<Defs extends Definitions>(
+  definitions: Defs
+): { [name in keyof Defs]: Template } {
+  const templates = Object.keys(definitions).reduce<{
+    [key: string]: Template;
+  }>((templates, name) => {
+    templates[name] = build(definitions[name]);
+    return templates;
+  }, {});
+  return templates as { [name in keyof Defs]: Template };
+}
+
+export const templates = {
+  root: build("/"),
+  order: buildAll(order),
+  reservation: buildAll(reservation),
+  bedbank: buildAll(bedbank),
+  offer: buildAll(offer),
+  calendar: buildAll(calendar),
+  flight: buildAll(flight),
+  loyalty: buildAll(loyalty),
+  auth: buildAll(auth),
+  content: buildAll(content),
+  payment: buildAll(payment),
+  voucher: buildAll(voucher),
+};

--- a/src/loyalty.ts
+++ b/src/loyalty.ts
@@ -1,15 +1,10 @@
-import qargs from "./qargs";
-
 export const partnership = "/api/loyalty/partnerships/{code}";
 
-export const partnerships =
-  "/api/loyalty/partnerships" + qargs("brand", "region", "currency");
+export const partnerships = "/api/loyalty/partnerships{?brand,region,currency}";
 
 export const membership = "/api/loyalty/memberships/{code}";
 
-export const memberships =
-  "/api/loyalty/memberships" + qargs("brand", "region", "currency");
+export const memberships = "/api/loyalty/memberships{?brand,region,currency}";
 
 export const memberships_limits =
-  "/api/loyalty/memberships/limits" +
-  qargs("brand", "customer_id", "membership_code", "membership_number");
+  "/api/loyalty/memberships/limits{?brand,customer_id,membership_code,membership_number}";

--- a/src/offer.ts
+++ b/src/offer.ts
@@ -1,91 +1,29 @@
-import qargs from "./qargs";
-
 export const public_offer_filters =
   "/api/public-offer-filters{?brand,region,type,locations,holiday_types,benefit_types,campaigns,memberships,check_in,check_out,occupancy,place_ids,property_ids}";
 
 export const public_offers =
-  "/api/public-offers" +
-  qargs(
-    "page",
-    "limit",
-    "platform",
-    "region",
-    "brand",
-    "locations",
-    "holiday_types",
-    "campaigns",
-    "benefit_types",
-    "strategy_applied",
-    "exclude_offer_ids",
-    "offer_ids",
-    "slim",
-    "flight_origin",
-    "user_id",
-    "recommendation_id",
-    "sort_by",
-    "memberships",
-    "only_ids",
-    "type*",
-    "flexible_packages",
-    "lowest_price_only",
-    "include_package_ids",
-    "check_in",
-    "check_out",
-    "place_ids",
-    "property_ids",
-    "occupancy",
-    "personalisation",
-    "remove_addons",
-    "exclude_properties",
-    "flexible_as_rates"
-  );
+  "/api/public-offers{?page,limit,platform,region,brand,locations,holiday_types,campaigns,benefit_types,strategy_applied,exclude_offer_ids,offer_ids,slim,flight_origin,user_id,recommendation_id,sort_by,memberships,only_ids,type*,flexible_packages,lowest_price_only,include_package_ids,check_in,check_out,place_ids,property_ids,occupancy,personalisation,remove_addons,exclude_properties,flexible_as_rates}";
 
 export const public_offer =
-  "/api/public-offers/{id}" +
-  qargs(
-    "platform",
-    "region",
-    "brand",
-    "all_packages",
-    "flight_origin",
-    "user_id",
-    "memberships",
-    "provider*",
-    "flexible_packages",
-    "remove_addons",
-    "exclude_properties",
-    "flexible_as_rates"
-  );
+  "/api/public-offers/{id}{?platform,region,brand,all_packages,flight_origin,user_id,memberships,provider*,flexible_packages,remove_addons,exclude_properties,flexible_as_rates}";
 
 export const public_offer_packages =
-  "/api/public-offers/{offer_id}/packages" +
-  qargs(
-    "region",
-    "brand",
-    "all_packages",
-    "remove_addons",
-    "exclude_properties",
-    "flexible_as_rates"
-  );
+  "/api/public-offers/{offer_id}/packages{?region,brand,all_packages,remove_addons,exclude_properties,flexible_as_rates}";
 
 export const publicOfferPackages =
-  "/api/v2/public-offers/{offerId}/packages" +
-  qargs("brand", "checkIn", "checkOut", "occupancy*", "region", "medium");
+  "/api/v2/public-offers/{offerId}/packages{?brand,checkIn,checkOut,occupancy*,region,medium}";
 
 export const publicOffer =
-  "/api/v2/public-offers/{id}" + qargs("platform", "region", "brand", "userId");
+  "/api/v2/public-offers/{id}{?platform,region,brand,userId}";
 
 export const publicOffers =
-  "/api/v2/public-offers" +
-  qargs("offerIds", "occupancy", "checkIn", "checkOut", "region", "brand");
+  "/api/v2/public-offers{?offerIds,occupancy,checkIn,checkOut,region,brand}";
 
 export const publicOfferList =
-  "/api/v2/public-offers/list" +
-  qargs("placeIds", "occupancy", "checkIn", "checkOut", "region", "offerType");
+  "/api/v2/public-offers/list{?placeIds,occupancy,checkIn,checkOut,region,offerType}";
 
 export const publicOfferListByProperty =
-  "/api/v2/public-offers/list/property/{propertyId}" +
-  qargs("occupancy", "checkIn", "checkOut", "region", "brand", "searchNearby");
+  "/api/v2/public-offers/list/property/{propertyId}{?occupancy,checkIn,checkOut,region,brand,searchNearby}";
 
 export const vendor = "/api/vendor/{id}";
 export const vendor_offers = "/api/vendor-offers{?email}";

--- a/src/order.ts
+++ b/src/order.ts
@@ -1,22 +1,7 @@
-import qargs from "./qargs";
-
 export const order = "/api/orders/{id}";
 
 export const orders =
-  "/api/orders" +
-  qargs(
-    "page",
-    "per_page",
-    "order_by",
-    "order_direction",
-    "customer_id",
-    "vendor_id",
-    "utm_source",
-    "le_label",
-    "le_attribution",
-    "updated_since",
-    "booking_numbers"
-  );
+  "/api/orders{?page,per_page,order_by,order_direction,customer_id,vendor_id,utm_source,le_label,le_attribution,updated_since,booking_numbers}";
 
 export const order_item = "/api/orders/{order_id}/items/{id}";
 

--- a/src/qargs.ts
+++ b/src/qargs.ts
@@ -1,3 +1,0 @@
-export default function qargs(...parts: string[]): string {
-  return `{?${parts.join(",")}}`;
-}

--- a/src/reservation.ts
+++ b/src/reservation.ts
@@ -12,39 +12,39 @@ export const property = "/api/properties/{id}";
 
 // Room Types
 export const room_types = "/api/properties/{property_id}/room-types";
-export const room_type = `${room_types}/{id}`;
+export const room_type = `${room_types}/{id}` as const;
 
 // Rate Plans
 export const rate_plans = "/api/rate-plans{?id_salesforce_external}";
 export const rate_plan = "/api/rate-plans{id}";
 
 // Room Rates
-export const room_rates = `${room_types}/{room_type_id}/room-rates`;
-export const room_rate = `${room_rates}/{id}`;
+export const room_rates = `${room_types}/{room_type_id}/room-rates` as const;
+export const room_rate = `${room_rates}/{id}` as const;
 
 // Legacy Capacities
-export const room_type_capacities = `${room_types}/{room_type_id}/capacities`;
-export const room_type_capacity = `${room_type_capacities}/{id}`;
+export const room_type_capacities = `${room_types}/{room_type_id}/capacities` as const;
+export const room_type_capacity = `${room_type_capacities}/{id}` as const;
 
 // Capacities
-export const room_rate_capacities = `${room_rates}/{room_rate_id}/capacities`;
-export const room_rate_capacity = `${room_rate_capacities}/{id}`;
+export const room_rate_capacities = `${room_rates}/{room_rate_id}/capacities` as const;
+export const room_rate_capacity = `${room_rate_capacities}/{id}` as const;
 
 // Extra guest surcharges
-export const extra_guest_surcharges = `${room_rates}/{room_rate_id}/extra-guest-surcharges`;
-export const extra_guest_surcharge = `${extra_guest_surcharges}/{id}`;
+export const extra_guest_surcharges = `${room_rates}/{room_rate_id}/extra-guest-surcharges` as const;
+export const extra_guest_surcharge = `${extra_guest_surcharges}/{id}` as const;
 
 // Legacy Included Guests
-export const included_guests = `${room_type}/included-guests`;
-export const included_guest = `${included_guests}/{id}`;
+export const included_guests = `${room_type}/included-guests` as const;
+export const included_guest = `${included_guests}/{id}` as const;
 
 // Included Guests
-export const room_rate_included_guests = `${room_rates}/{room_rate_id}/included-guests`;
-export const room_rate_included_guest = `${room_rate_included_guests}/{id}`;
+export const room_rate_included_guests = `${room_rates}/{room_rate_id}/included-guests` as const;
+export const room_rate_included_guest = `${room_rate_included_guests}/{id}` as const;
 
 // Surcharges
-export const room_rate_surcharge_dates = `${room_rates}/{room_rate_id}/surcharge-dates`;
-export const room_rate_surcharge_date = `${room_rate_surcharge_dates}/{id}`;
+export const room_rate_surcharge_dates = `${room_rates}/{room_rate_id}/surcharge-dates` as const;
+export const room_rate_surcharge_date = `${room_rate_surcharge_dates}/{id}` as const;
 
 export const room_type_availability =
   "/api/properties/{property_id}/room-types/{id}/availability";

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,47 +1,70 @@
 import assert from "assert";
-import * as templates from "../src";
+import * as uriTemplates from "../src";
 
 describe("#get", function () {
   it("should return the rfc6570", function () {
-    const template = templates.get("properties");
+    const template = uriTemplates.get("properties");
 
-    assert.equal(
+    assert.strictEqual(
       template.rfc6570,
       "/api/properties{?id_salesforce_external,limit,page}"
     );
   });
 
   it("should expand the template", function () {
-    const template = templates.get("properties");
+    const template = uriTemplates.get("properties");
 
-    assert.equal(
+    assert.strictEqual(
       template.expand({ id_salesforce_external: 1 }),
       "/api/properties?id_salesforce_external=1"
     );
   });
 
   it("should expand the template (query fn builder)", function () {
-    const template = templates.get("public_offers");
+    const template = uriTemplates.get("public_offers");
 
-    assert.equal(template.expand({ page: 1 }), "/api/public-offers?page=1");
+    assert.strictEqual(
+      template.expand({ page: 1 }),
+      "/api/public-offers?page=1"
+    );
   });
 
   it("should expand the template with no query", function () {
-    const template = templates.get("wishlist");
+    const template = uriTemplates.get("wishlist");
 
-    assert.equal(template.expand(), "/api/wishlist");
+    assert.strictEqual(template.expand(), "/api/wishlist");
   });
 });
 
 describe("#mock", function () {
   it("should return the rfc6570", function () {
-    const template = templates.mock(
+    const template = uriTemplates.mock(
       "/api/properties{?id_salesforce_external,limit,page}"
     );
 
-    assert.equal(
+    assert.strictEqual(
       template.rfc6570,
       "/api/properties{?id_salesforce_external,limit,page}"
+    );
+  });
+});
+
+describe("#templates", function () {
+  it("should return the rfc6570", function () {
+    const template = uriTemplates.templates.reservation.properties;
+
+    assert.strictEqual(
+      template.rfc6570,
+      "/api/properties{?id_salesforce_external,limit,page}"
+    );
+  });
+
+  it("should expand the template", function () {
+    const template = uriTemplates.templates.reservation.properties;
+
+    assert.strictEqual(
+      template.expand({ id_salesforce_external: 1 }),
+      "/api/properties?id_salesforce_external=1"
     );
   });
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,9 +1,9 @@
 import assert from "assert";
-import * as uriTemplates from "../src";
+import * as uri from "../src";
 
 describe("#get", function () {
   it("should return the rfc6570", function () {
-    const template = uriTemplates.get("properties");
+    const template = uri.get("properties");
 
     assert.strictEqual(
       template.rfc6570,
@@ -12,7 +12,7 @@ describe("#get", function () {
   });
 
   it("should expand the template", function () {
-    const template = uriTemplates.get("properties");
+    const template = uri.get("properties");
 
     assert.strictEqual(
       template.expand({ id_salesforce_external: 1 }),
@@ -21,7 +21,7 @@ describe("#get", function () {
   });
 
   it("should expand the template (query fn builder)", function () {
-    const template = uriTemplates.get("public_offers");
+    const template = uri.get("public_offers");
 
     assert.strictEqual(
       template.expand({ page: 1 }),
@@ -30,7 +30,7 @@ describe("#get", function () {
   });
 
   it("should expand the template with no query", function () {
-    const template = uriTemplates.get("wishlist");
+    const template = uri.get("wishlist");
 
     assert.strictEqual(template.expand(), "/api/wishlist");
   });
@@ -38,7 +38,7 @@ describe("#get", function () {
 
 describe("#mock", function () {
   it("should return the rfc6570", function () {
-    const template = uriTemplates.mock(
+    const template = uri.mock(
       "/api/properties{?id_salesforce_external,limit,page}"
     );
 
@@ -51,20 +51,24 @@ describe("#mock", function () {
 
 describe("#templates", function () {
   it("should return the rfc6570", function () {
-    const template = uriTemplates.templates.reservation.properties;
+    const template = uri.templates.offer.offers;
 
     assert.strictEqual(
       template.rfc6570,
-      "/api/properties{?id_salesforce_external,limit,page}"
+      "/api/offers{?page,limit,platform,region,filter,brand}{&type*}"
     );
   });
 
   it("should expand the template", function () {
-    const template = uriTemplates.templates.reservation.properties;
+    const template = uri.templates.offer.offers;
 
     assert.strictEqual(
-      template.expand({ id_salesforce_external: 1 }),
-      "/api/properties?id_salesforce_external=1"
+      template.expand({
+        region: "AU",
+        brand: "luxuryescapes",
+        type: ["hotel", "tour"],
+      }),
+      "/api/offers?region=AU&brand=luxuryescapes&type=hotel&type=tour"
     );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1628,10 +1628,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
-  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+typescript@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
+  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -1639,6 +1639,11 @@ uri-js@^4.2.2:
   integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
   dependencies:
     punycode "^2.1.0"
+
+uri-template-param-types@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/uri-template-param-types/-/uri-template-param-types-0.2.0.tgz#e95173c4dcc9016b790be58fc204e04267335e04"
+  integrity sha512-+dPK0CR3ZfHjVX5C5ICNeKmrmdw8fkCoiMd00OIY8UZiPRn8npgF2Tf84GzEMJgFrVOyuj4k5WItUTcw6DGIOw==
 
 url-template@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
Sort of a spiritual successor to https://github.com/lux-group/www-le-customer/pull/5209

`lib-uri-templates` is annoying to use, because:

- The templates must be looked up via a string (e.g. `uriTemplates.get('publicOffer')`)
- There's no type safety or autocompletion when passing in parameters to the template

This PR aims to solve both those problems.

- Lookup via object (e.g. `const template = uri.templates.offer.offers`), with autocompletion
- Using [uri-template-param-types](https://www.npmjs.com/package/uri-template-param-types) to make the params typesafe and autocompleting

To make the parameter typing work, I've had to remove the `qargs` helper so that TS can get the actual string value. Also the templates in `src/reservation.ts` which are defined using template literals have to have `as const` after them to tell TS to evaluate them properly instead of giving them generic `string` type.