### PR TITLE
Use permissive version of `URIParams`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-uri-templates",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "All our routes in a repo for profit",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "url-template": "^2.0.8",
-    "uri-template-param-types": "^0.2.0"
+    "uri-template-param-types": "^0.3.0"
   },
   "devDependencies": {
     "@types/assert": "^1.5.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import urlTemplate from "url-template";
-import { URIParams } from "uri-template-param-types";
+import { PermissiveURIParams } from "uri-template-param-types";
 
 import * as order from "./order";
 import * as reservation from "./reservation";
@@ -13,7 +13,9 @@ import * as content from "./content";
 import * as payment from "./payment";
 import * as voucher from "./voucher";
 
-type ExpandFunc<Def extends string> = (query?: URIParams<Def>) => string;
+type ExpandFunc<Def extends string> = (
+  query?: PermissiveURIParams<Def>
+) => string;
 
 interface Template<Def extends string = string> {
   readonly rfc6570: Def;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,10 +1640,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-uri-template-param-types@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/uri-template-param-types/-/uri-template-param-types-0.2.0.tgz#e95173c4dcc9016b790be58fc204e04267335e04"
-  integrity sha512-+dPK0CR3ZfHjVX5C5ICNeKmrmdw8fkCoiMd00OIY8UZiPRn8npgF2Tf84GzEMJgFrVOyuj4k5WItUTcw6DGIOw==
+uri-template-param-types@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/uri-template-param-types/-/uri-template-param-types-0.3.0.tgz#f682eeedd383677750eee89c0d98233b5849e9f8"
+  integrity sha512-N97o8xvfceYejfdC1EY+oktWf3Y3thEhaDqrmN/qk4v4h0h4ljd5h0EGHrph8l52La7X8bwMCL5hf050XFAy1A==
 
 url-template@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
The `URIParams` type I added doesn't allow boolean values for URI parameters (as per the RFC6570 spec). But the `url-templates` package does accept boolean values and also nulls, so I updated `uri-template-param-types` to add a new type, `PermissiveURIParams`, which allows those values.

So now the type checking for URI parameters will match what `url-templates` actually accepts.