### PR TITLE
po v2 adding flight origin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-uri-templates",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "All our routes in a repo for profit",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/offer.ts
+++ b/src/offer.ts
@@ -2,10 +2,10 @@ export const public_offer_filters =
   "/api/public-offer-filters{?brand,region,type,locations,holiday_types,benefit_types,campaigns,memberships,check_in,check_out,occupancy,place_ids,property_ids}";
 
 export const public_offers =
-  "/api/public-offers{?page,limit,platform,region,brand,locations,holiday_types,campaigns,benefit_types,strategy_applied,exclude_offer_ids,offer_ids,slim,flight_origin,user_id,recommendation_id,sort_by,memberships,only_ids,type*,flexible_packages,lowest_price_only,include_package_ids,check_in,check_out,place_ids,property_ids,occupancy,personalisation,remove_addons,exclude_properties,flexible_as_rates}";
+  "/api/public-offers{?page,limit,platform,region,brand,locations,holiday_types,campaigns,benefit_types,strategy_applied,exclude_offer_ids,offer_ids,slim,flight_origin,sort_by,memberships,only_ids,type*,flexible_packages,lowest_price_only,include_package_ids,check_in,check_out,place_ids,property_ids,occupancy,personalisation,remove_addons,exclude_properties,flexible_as_rates}";
 
 export const public_offer =
-  "/api/public-offers/{id}{?platform,region,brand,all_packages,flight_origin,user_id,memberships,provider*,flexible_packages,remove_addons,exclude_properties,flexible_as_rates}";
+  "/api/public-offers/{id}{?platform,region,brand,all_packages,flight_origin,memberships,provider*,flexible_packages,remove_addons,exclude_properties,flexible_as_rates}";
 
 export const public_offer_packages =
   "/api/public-offers/{offer_id}/packages{?region,brand,all_packages,remove_addons,exclude_properties,flexible_as_rates}";
@@ -14,7 +14,7 @@ export const publicOfferPackages =
   "/api/v2/public-offers/{offerId}/packages{?brand,checkIn,checkOut,occupancy*,region,medium}";
 
 export const publicOffer =
-  "/api/v2/public-offers/{id}{?platform,region,brand,userId,flightOrigin}";
+  "/api/v2/public-offers/{id}{?platform,region,brand,flightOrigin}";
 
 export const publicOffers =
   "/api/v2/public-offers{?offerIds,occupancy,checkIn,checkOut,region,brand,flightOrigin}";

--- a/src/offer.ts
+++ b/src/offer.ts
@@ -14,10 +14,10 @@ export const publicOfferPackages =
   "/api/v2/public-offers/{offerId}/packages{?brand,checkIn,checkOut,occupancy*,region,medium}";
 
 export const publicOffer =
-  "/api/v2/public-offers/{id}{?platform,region,brand,userId}";
+  "/api/v2/public-offers/{id}{?platform,region,brand,userId,flightOrigin}";
 
 export const publicOffers =
-  "/api/v2/public-offers{?offerIds,occupancy,checkIn,checkOut,region,brand}";
+  "/api/v2/public-offers{?offerIds,occupancy,checkIn,checkOut,region,brand,flightOrigin}";
 
 export const publicOfferList =
   "/api/v2/public-offers/list{?placeIds,occupancy,checkIn,checkOut,region,offerType,brand}";

--- a/test/test.ts
+++ b/test/test.ts
@@ -20,6 +20,34 @@ describe("#get", function () {
     );
   });
 
+  it("should expand the publicOffer template", function () {
+    const template = uri.get("publicOffer");
+
+    assert.strictEqual(
+      template.expand({
+        id: 1,
+        region: "AU",
+        brand: "luxuryescapes",
+        flightOrigin: "SYD",
+      }),
+      "/api/v2/public-offers/1?region=AU&brand=luxuryescapes&flightOrigin=SYD"
+    );
+  });
+
+  it("should expand the publicOffers template", function () {
+    const template = uri.get("publicOffers");
+
+    assert.strictEqual(
+      template.expand({
+        offerIds: [1, 2, 3],
+        region: "AU",
+        brand: "luxuryescapes",
+        flightOrigin: "SYD",
+      }),
+      "/api/v2/public-offers?offerIds=1,2,3&region=AU&brand=luxuryescapes&flightOrigin=SYD"
+    );
+  });
+
   it("should expand the template (query fn builder)", function () {
     const template = uri.get("public_offers");
 


### PR DESCRIPTION
- adding flight origin 
- remove user and recommendation id

I do not believe that the user and recommendation id is used anywhere it was 
implemented by the marketing platform team for home page recommendations.

I have put this as a seperate commit and we can only merge the adding of flight origin
if needed
