### PR TITLE
[CRO-457] Add offer_ids qs parameters into offer filter API.

### DIFF
--- a/src/offer.ts
+++ b/src/offer.ts
@@ -1,5 +1,5 @@
 export const public_offer_filters =
-  "/api/public-offer-filters{?brand,region,type,locations,holiday_types,benefit_types,campaigns,memberships,check_in,check_out,occupancy,place_ids,property_ids}";
+  "/api/public-offer-filters{?brand,region,type,locations,holiday_types,benefit_types,campaigns,memberships,check_in,check_out,occupancy,place_ids,property_ids,offer_ids}";
 
 export const public_offers =
   "/api/public-offers{?page,limit,platform,region,brand,locations,holiday_types,campaigns,benefit_types,strategy_applied,exclude_offer_ids,offer_ids,slim,flight_origin,sort_by,memberships,only_ids,type*,flexible_packages,lowest_price_only,include_package_ids,check_in,check_out,place_ids,property_ids,occupancy,personalisation,remove_addons,exclude_properties,flexible_as_rates}";


### PR DESCRIPTION
Based on the changes of https://github.com/lux-group/svc-public-offer/pull/1338.

The offer list filter API will be extended to support the `offer_ids` parameter on the offer search result page.