### PR TITLE
v1.7.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-uri-templates",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "description": "All our routes in a repo for profit",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Bumping the version number to v1.7.12

I guess I should include this change with my previous PR https://github.com/lux-group/lib-uri-templates/pull/156
Any suggestion is welcome.