### PR TITLE
[TOUR-417] TourV2 Season compare fix - Adds necessary query parameter to URL template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-uri-templates",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "All our routes in a repo for profit",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/tour.ts
+++ b/src/tour.ts
@@ -1,4 +1,4 @@
 export const tour_reservation_snapshot =
   "/api/v2/tours/reservations/{reservation_id}/snapshot";
 
-export const season_compare = "/api/v2/tours/seasons/{season_id}/compare";
+export const season_compare = "/api/v2/tours/seasons/{season_id}/compare{?selectedSeasonId}";

--- a/src/tour.ts
+++ b/src/tour.ts
@@ -1,4 +1,5 @@
 export const tour_reservation_snapshot =
   "/api/v2/tours/reservations/{reservation_id}/snapshot";
 
-export const season_compare = "/api/v2/tours/seasons/{season_id}/compare{?selectedSeasonId}";
+export const season_compare =
+  "/api/v2/tours/seasons/{season_id}/compare{?selectedSeasonId}";


### PR DESCRIPTION
This makes the final fix for the template, which also includes the query parameter for the `selectedSeasonId` param as agreed previously (this name was taken while looking at the backend repo for `svc-tour`) in the seasons presenter