### PR TITLE
[CRO-474] Add clientTime parameter into offers API.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-uri-templates",
-  "version": "1.7.17",
+  "version": "1.7.18",
   "description": "All our routes in a repo for profit",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/offer.ts
+++ b/src/offer.ts
@@ -17,7 +17,7 @@ export const publicOffer =
   "/api/v2/public-offers/{id}{?platform,region,brand,flightOrigin}";
 
 export const publicOffers =
-  "/api/v2/public-offers{?offerIds,occupancy,checkIn,checkOut,region,brand,flightOrigin}";
+  "/api/v2/public-offers{?offerIds,occupancy,checkIn,checkOut,region,brand,flightOrigin,clientTime}";
 
 export const publicOfferList =
   "/api/v2/public-offers/list{?placeIds,occupancy,checkIn,checkOut,region,offerType,brand,sortBy,campaigns,holidayTypes,locations,strategyApplied,bounds,cancellationPolicies,amenities}";


### PR DESCRIPTION
Add the new `clientTime` parameter into the offers API, which will be used to generate offer views today.