### PR TITLE
[CRO-535] Remove the old clientTime parameter from offer API.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-uri-templates",
-  "version": "1.7.23",
+  "version": "1.7.24",
   "description": "All our routes in a repo for profit",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/offer.ts
+++ b/src/offer.ts
@@ -20,7 +20,7 @@ export const publicOfferExtra =
   "/api/v2/public-offers/{id}/extra{?region,brand,clientTime}";
 
 export const publicOffers =
-  "/api/v2/public-offers{?offerIds,occupancy,checkIn,checkOut,region,brand,flightOrigin,clientTime}";
+  "/api/v2/public-offers{?offerIds,occupancy,checkIn,checkOut,region,brand,flightOrigin}";
 
 export const publicOfferList =
   "/api/v2/public-offers/list{?placeIds,occupancy,checkIn,checkOut,region,offerType,brand,sortBy,campaigns,holidayTypes,locations,strategyApplied,bounds,cancellationPolicies,amenities}";


### PR DESCRIPTION
The offer views today have been moved to a new endpoint, so the `clientTime` in the offer API is not needed.