### PR TITLE
[CRO-2511]: remove svc-voucher data from lib-uri-template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-uri-templates",
-  "version": "1.7.36",
+  "version": "1.7.37",
   "description": "All our routes in a repo for profit",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import * as loyalty from "./loyalty";
 import * as auth from "./auth";
 import * as content from "./content";
 import * as payment from "./payment";
-import * as voucher from "./voucher";
 import * as search from "./search";
 import * as tour from "./tour";
 import * as referral from "./referral";
@@ -51,7 +50,6 @@ const definitions: Definitions = {
   ...auth,
   ...content,
   ...payment,
-  ...voucher,
   ...search,
   ...tour,
   ...referral,
@@ -109,7 +107,6 @@ export const templates = {
   auth: buildAll(auth),
   content: buildAll(content),
   payment: buildAll(payment),
-  voucher: buildAll(voucher),
   search: buildAll(search),
   tour: buildAll(tour),
   referral: buildAll(referral),

--- a/src/voucher.ts
+++ b/src/voucher.ts
@@ -1,4 +1,0 @@
-export const voucher = "/api/vouchers/{vendor_id}/{offer_id}/{voucher_code}";
-
-export const voucher_status =
-  "/api/vouchers/public-status/{vendor_id}/{offer_id}";


### PR DESCRIPTION
Jira: https://aussiecommerce.atlassian.net/jira/software/projects/CRO/boards/114?selectedIssue=CRO-2511

Related PR: https://github.com/lux-group/svc-public-offer/pull/2050

We're removing svc-voucher and all it integrations as well. This will be removed from svc-public-offer, so we need to remove it from all offer snapshots as well.