### PR TITLE
CRO-3550: Remove reference to old offer list endpoint

### DIFF
--- a/src/offer.ts
+++ b/src/offer.ts
@@ -22,9 +22,6 @@ export const publicOfferExtra =
 export const publicOffers =
   "/api/v2/public-offers{?offerIds,occupancy,checkIn,checkOut,region,brand,currency,flightOrigin,preview}";
 
-export const publicOfferList =
-  "/api/v2/public-offers/list{?placeIds,occupancy,checkIn,checkOut,region,offerType,brand,sortBy,campaigns,holidayTypes,locations,strategyApplied,bounds,amenities,ignoreVisibility}";
-
 export const publicOfferListByProperty =
   "/api/v2/public-offers/list/property/{propertyId}{?occupancy,checkIn,checkOut,region,brand,searchNearby,sortBy}";
 


### PR DESCRIPTION
The old deal ordering is not used anymore so it is being removed from svc-public-offer https://github.com/lux-group/svc-public-offer/pull/2241

Any references to the endpoint are to be removed.